### PR TITLE
Allow metadata-json verification without extra source uploads when content is embedded

### DIFF
--- a/app/components/verification/MetadataValidation.tsx
+++ b/app/components/verification/MetadataValidation.tsx
@@ -1,73 +1,21 @@
-import React, { useEffect, useState } from "react";
-import { validateMetadataSources } from "../../utils/metadataValidation";
+import { useState } from "react";
+import type { ValidationSummary } from "../../utils/metadataValidation";
 import MetadataValidationModal from "./MetadataValidationModal";
-
-interface ValidationResult {
-  allRequiredFound: boolean;
-  missingCount: number;
-  unnecessaryCount: number;
-  sources: Array<{
-    expectedFileName: string;
-    matchedFileName?: string;
-    status: "found" | "missing" | "embedded";
-    expectedHash: string;
-    actualHash?: string;
-    isValid: boolean;
-    fileSize?: number;
-    content?: string;
-  }>;
-  unnecessaryFiles: Array<{
-    fileName: string;
-    actualHash: string;
-    fileSize: number;
-  }>;
-  message: string;
-}
 
 interface MetadataValidationProps {
   metadataFile: File | null;
-  uploadedFiles: File[];
-  onValidationChange?: (isValid: boolean) => void;
+  validationResult: ValidationSummary | null;
+  validationError: string | null;
+  isValidating: boolean;
 }
 
 export default function MetadataValidation({
   metadataFile,
-  uploadedFiles,
-  onValidationChange,
+  validationResult,
+  validationError,
+  isValidating,
 }: MetadataValidationProps) {
-  const [isValidating, setIsValidating] = useState(false);
-  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
-  const [validationError, setValidationError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
-
-  useEffect(() => {
-    const validateMetadata = async () => {
-      if (!metadataFile) {
-        setValidationResult(null);
-        setValidationError(null);
-        onValidationChange?.(false);
-        return;
-      }
-
-      setIsValidating(true);
-      setValidationError(null);
-
-      try {
-        const result = await validateMetadataSources(metadataFile, uploadedFiles);
-        setValidationResult(result);
-        onValidationChange?.(result.allRequiredFound);
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Validation failed";
-        setValidationError(errorMessage);
-        setValidationResult(null);
-        onValidationChange?.(false);
-      } finally {
-        setIsValidating(false);
-      }
-    };
-
-    validateMetadata();
-  }, [metadataFile, uploadedFiles, onValidationChange]);
 
   if (!metadataFile) {
     return null;

--- a/app/utils/metadataValidation.ts
+++ b/app/utils/metadataValidation.ts
@@ -1,13 +1,13 @@
 import { id as keccak256str } from "ethers";
 
-interface MetadataSource {
+export interface MetadataSource {
   keccak256: string;
   content?: string;
   license?: string;
   urls?: string[];
 }
 
-interface SourceValidationResult {
+export interface SourceValidationResult {
   expectedFileName: string;
   matchedFileName?: string; // Actual uploaded file name that matched the hash
   status: "found" | "missing" | "embedded";
@@ -18,7 +18,7 @@ interface SourceValidationResult {
   content?: string; // For embedded sources
 }
 
-interface ValidationSummary {
+export interface ValidationSummary {
   allRequiredFound: boolean;
   missingCount: number;
   unnecessaryCount: number;


### PR DESCRIPTION
See second point of #8.

With this PR:
- Run `validateMetadataSources` once in `VerificationForm` and feed the result to both the UI and form validation, so metadata-json respects embedded content sources.
- Form validation now trusts the shared validation result instead of checking `uploadedFiles.length`, so users aren’t forced to upload extra sources when metadata already embeds them.
- The metadata validation card just renders the shared result/error/pending state, avoiding duplicate checks and keeping the message consistent.