### PR TITLE
Add staging/dev environment banner

### DIFF
--- a/app/components/StagingBanner.tsx
+++ b/app/components/StagingBanner.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+// Shown only on non-production deployments. Production builds set
+// VITE_ENV to "production"; anything else (e.g. "staging") is non-production.
+const isStaging = Boolean(import.meta.env.VITE_ENV) && import.meta.env.VITE_ENV !== "production";
+
+export default function StagingBanner() {
+  // Set on the client only to avoid an SSR/prerender hydration mismatch.
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    setUrl(window.location.href);
+  }, []);
+
+  if (!isStaging) {
+    return null;
+  }
+
+  return (
+    <div className="w-full bg-cerulean-blue-500 text-white text-center font-medium py-3 px-4">
+      🚧 You are on the <span className="font-bold">staging/dev</span> environment{" "}
+      <span className="mx-1 text-xl align-middle">—</span>{" "}
+      <span className="font-mono font-normal">{url}</span>
+    </div>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,6 +6,7 @@ import "./app.css";
 import { ServerConfigProvider } from "./contexts/ServerConfigContext";
 import { ChainsProvider } from "./contexts/ChainsContext";
 import { CompilerVersionsProvider } from "./contexts/CompilerVersionsContext";
+import StagingBanner from "./components/StagingBanner";
 
 export const links: Route.LinksFunction = () => [];
 
@@ -27,6 +28,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         )}
       </head>
       <body>
+        <StagingBanner />
         <ServerConfigProvider>
           <ChainsProvider>
             <CompilerVersionsProvider>


### PR DESCRIPTION
Adds a consistent banner shown only on non-production deployments, matching the one added to sourcify-ui.

## What
- New `StagingBanner` component rendered at the top of `root.tsx`.
- Full-width bar in the sourcify blue (`cerulean-blue-500`), white centered text:
  > 🚧 You are on the **staging/dev** environment — `<current URL>`
- Hidden on production builds.

## Detection
Uses `import.meta.env.VITE_ENV !== "production"`, the same convention already used for the `(<env> environment - <serverUrl>)` prefixes in `PageLayout`/route titles. The URL is read on the client in a `useEffect` to avoid an SPA-prerender hydration mismatch.

Part of a set of matching banners across sourcify-ui, verify.sourcify.dev, and repo.sourcify.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)